### PR TITLE
Swap querystring for qs

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "scripts": ["index.js"],
   "dependencies": {
-    "component/querystring": "*",
-    "segmentio/substitute": "*"
+    "segmentio/substitute": "*",
+    "hapijs/qs": "4.0.0"
   },
   "development": {
     "visionmedia/mocha": "*",

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var stringify = require('querystring').stringify;
+var stringify = require('qs').stringify;
 var sub = require('substitute');
 
 /**


### PR DESCRIPTION
Swaps querystring for qs. Querystring doesn't handle nested POJOs properly serializing them as `[object Object]`

@yields 
